### PR TITLE
Add note about playwright dir structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,6 @@ An opinionated starter template for crafting WordPress block plugins.
 
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/kevinbatdorf.svg?style=social&label=Follow%20%40kevinbatdorf)](https://twitter.com/kevinbatdorf)
 
-### Usage
-
-- Click "Use this template" at the top+right of the repo
-- Search/replace `kevinbatdorf` with your namespace/username
-- Search/replace `block-starter` with your plugin slug
-- Update `block-starter.php` to match your new plugin slug
-- Run `composer install` to install PHP dev dependencies (sometimes needed for autocomplete in IDEs)
-- Run `npm install` to install dependencies
-- Run `npm run start` to start the dev server
 
 ### Features
 
@@ -25,6 +16,20 @@ An opinionated starter template for crafting WordPress block plugins.
 - Playwright for end-to-end testing using WP Playground
 - Runs the Plugin Check from WordPress on main and release
 - Auto deployment to WordPress.org SVN on release (via 10up Action)
+
+### Usage
+
+- Click "Use this template" at the top+right of the repo
+- Search/replace `kevinbatdorf` with your namespace/username
+- Search/replace `block-starter` with your plugin slug.
+- Update `block-starter.php` to match your new plugin slug
+- Run `composer install` to install PHP dev dependencies (sometimes needed for autocomplete in IDEs)
+- Run `npm install` to install dependencies
+- Run `npm run start` to start the dev server
+
+### Note
+
+- If your plugin slug doesn't match your GitHub repo name, you'll need to update the `runPHP` step in the `tests/playwright.yml` workflow to require the correct file.
 
 
 <div align="center">

--- a/tests/blueprint.json
+++ b/tests/blueprint.json
@@ -8,7 +8,7 @@
 		},
 		{
 			"step": "runPHP",
-			"code": "<?php require '/wordpress/wp-load.php'; require '/wordpress/wp-content/plugins/block-starter/tests/setup.php'; ?>"
+			"code": "<?php require '/wordpress/wp-content/plugins/simple-whiteboard/tests/setup.php'; ?>"
 		}
 	]
 }

--- a/tests/setup.php
+++ b/tests/setup.php
@@ -1,4 +1,5 @@
 <?php
+require '/wordpress/wp-load.php';
 
 $userId = 1;
 


### PR DESCRIPTION
Tests won't pass by default on new repos unless the dir in the blueprint matches the repo name. This PR adds a note explaining that. You can just edit the blueprint as well.