### PR TITLE
Remove Playwright test retries

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,11 +33,11 @@ const portMap = Object.fromEntries(
 
 export default defineConfig({
 	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 0,
+	retries: 0,
 	workers: 1,
 	reporter: "html",
 	use: {
-		trace: "on-first-retry",
+		trace: "retain-on-failure",
 		video: "retain-on-failure",
 		screenshot: "only-on-failure",
 	},


### PR DESCRIPTION
## Summary
- Remove CI test retries (`retries: process.env.CI ? 2 : 0` -> `retries: 0`) so flaky or failing tests are surfaced immediately instead of being masked by retry passes
- Change trace strategy from `on-first-retry` to `retain-on-failure` so traces are still captured for debugging when tests fail

## Motivation
Retries can hide real test failures by allowing a flaky test to pass on a subsequent attempt, making CI appear green when there are genuine issues. Removing retries ensures every failure is visible and must be addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)