### PR TITLE
Walk up directories to find closest blueprint.json

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -7,8 +7,9 @@ path: tests/**
 ## How It Works
 
 - Each `*.spec.ts` file is its own Playwright project, CI matrix job, and WP Playground instance.
-- The `playwright.config.ts` auto-discovers specs by finding `*.spec.ts` files and looking for the closest `blueprint.json` in the same directory or one level up.
-- Multiple specs can share a `blueprint.json` — they'll share a Playground instance. To isolate a test, give it its own directory with its own `blueprint.json`.
+- The `playwright.config.ts` auto-discovers specs by finding `*.spec.ts` files and walking up from the spec's directory to find the closest `blueprint.json`. A shared blueprint in `tests/` serves all specs unless a subdirectory provides its own override.
+- Multiple specs sharing the same `blueprint.json` share a Playground instance. To isolate a test, give it its own directory with its own `blueprint.json`.
+- Each spec = one separate GitHub Actions runner = one fresh WP Playground instance. They do NOT share state across specs. Tests within the same spec DO share state.
 - Each `blueprint.json` activates the plugin, defines `WP_DEBUG`, and runs `setup.php` to dismiss welcome guides.
 
 ## Editor Canvas vs Page

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,12 +6,23 @@ const BASE_PORT = 9400;
 const WP_VERSION = process.env.WP_VERSION || "latest";
 const RUN_PROJECT = process.env.RUN_PROJECT;
 
-// Discover spec files that have a blueprint.json in the same directory
+// Find the closest blueprint.json by walking up from the spec's directory
+function findBlueprint(dir: string): string | null {
+	let current = dir;
+	while (current !== "." && current !== "/") {
+		const bp = join(current, "blueprint.json");
+		if (existsSync(bp)) return bp;
+		current = dirname(current);
+	}
+	return null;
+}
+
+// Discover spec files that have a blueprint.json in their directory or any ancestor
 const specs = globSync("**/*.spec.ts", { ignore: ["node_modules/**"] })
 	.map((spec) => {
 		const dir = dirname(spec);
-		const blueprint = join(dir, "blueprint.json");
-		if (!existsSync(blueprint)) return null;
+		const blueprint = findBlueprint(dir);
+		if (!blueprint) return null;
 		return {
 			name: basename(spec, ".spec.ts"),
 			dir,
@@ -19,7 +30,10 @@ const specs = globSync("**/*.spec.ts", { ignore: ["node_modules/**"] })
 			blueprint,
 		};
 	})
-	.filter(Boolean);
+	.filter(
+		(s): s is { name: string; dir: string; spec: string; blueprint: string } =>
+			s !== null,
+	);
 
 const active = RUN_PROJECT
 	? specs.filter((p) => p.name === RUN_PROJECT)


### PR DESCRIPTION
Previously only looked in the same directory as the spec file. Now walks up ancestor directories so specs can share a parent blueprint without duplicating the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)